### PR TITLE
add GetStaticParametersForMethod and general cleanup

### DIFF
--- a/src/ProvidedTypes.fsi
+++ b/src/ProvidedTypes.fsi
@@ -1,13 +1,12 @@
-﻿// Based on code developed for the F# 3.0 Beta release of March 2012,
-// Copyright (c) Microsoft Corporation 2005-2012.
+﻿// Copyright (c) Microsoft Corporation 2005-2014 and other contributors.
 // This sample code is provided "as is" without warranty of any kind. 
 // We disclaim all warranties, either express or implied, including the 
 // warranties of merchantability and fitness for a particular purpose. 
-
+//
 // This file contains a set of helper types and methods for providing types in an implementation 
 // of ITypeProvider.
-
-// This code has been modified and is appropriate for use in conjunction with the F# 3.0, F# 3.1, and F# 3.1.1 releases
+//
+// This code has been modified and is appropriate for use in conjunction with the F# 3.0-4.0 releases
 
 
 namespace ProviderImplementation.ProvidedTypes
@@ -19,13 +18,24 @@ open Microsoft.FSharp.Core.CompilerServices
 
 /// Represents an erased provided parameter
 type ProvidedParameter =
-    inherit System.Reflection.ParameterInfo
+    inherit ParameterInfo
     new : parameterName: string * parameterType: Type * ?isOut:bool * ?optionalValue:obj -> ProvidedParameter
     member IsParamArray : bool with get,set
 
+/// Represents a provided static parameter.
+type ProvidedStaticParameter =
+    inherit ParameterInfo
+    new : parameterName: string * parameterType:Type * ?parameterDefaultValue:obj -> ProvidedStaticParameter
+
+    /// Add XML documentation information to this provided constructor
+    member AddXmlDoc            : xmlDoc: string -> unit    
+
+    /// Add XML documentation information to this provided constructor, where the computation of the documentation is delayed until necessary
+    member AddXmlDocDelayed   : xmlDocFunction: (unit -> string) -> unit   
+
 /// Represents an erased provided constructor.
 type ProvidedConstructor =    
-    inherit System.Reflection.ConstructorInfo
+    inherit ConstructorInfo
 
     /// Create a new provided constructor. It is not initially associated with any specific provided type definition.
     new : parameters: ProvidedParameter list -> ProvidedConstructor
@@ -62,7 +72,7 @@ type ProvidedConstructor =
     member IsTypeInitializer : bool with get,set
 
 type ProvidedMethod = 
-    inherit System.Reflection.MethodInfo
+    inherit MethodInfo
 
     /// Create a new provided method. It is not initially associated with any specific provided type definition.
     new : methodName:string * parameters: ProvidedParameter list * returnType: Type -> ProvidedMethod
@@ -100,11 +110,12 @@ type ProvidedMethod =
     /// Add a custom attribute to the provided method definition.
     member AddCustomAttribute : CustomAttributeData -> unit
 
-
+    /// Define the static parameters available on a statically parameterized method
+    member DefineStaticParameters     : parameters: ProvidedStaticParameter list * instantiationFunction: (string -> obj[] -> ProvidedMethod) -> unit
 
 /// Represents an erased provided property.
 type ProvidedProperty =
-    inherit System.Reflection.PropertyInfo
+    inherit PropertyInfo
 
     /// Create a new provided type. It is not initially associated with any specific provided type definition.
     new  : propertyName: string * propertyType: Type * ?parameters:ProvidedParameter list -> ProvidedProperty
@@ -140,7 +151,7 @@ type ProvidedProperty =
 
 /// Represents an erased provided property.
 type ProvidedEvent =
-    inherit System.Reflection.EventInfo
+    inherit EventInfo
 
     /// Create a new provided type. It is not initially associated with any specific provided type definition.
     new  : propertyName: string * eventHandlerType: Type -> ProvidedEvent
@@ -169,7 +180,7 @@ type ProvidedEvent =
 
 /// Represents an erased provided field.
 type ProvidedLiteralField =
-    inherit System.Reflection.FieldInfo
+    inherit FieldInfo
 
     /// Create a new provided field. It is not initially associated with any specific provided type definition.
     new  : fieldName: string * fieldType: Type * literalValue: obj -> ProvidedLiteralField
@@ -192,7 +203,7 @@ type ProvidedLiteralField =
 
 /// Represents an erased provided field.
 type ProvidedField =
-    inherit System.Reflection.FieldInfo
+    inherit FieldInfo
 
     /// Create a new provided field. It is not initially associated with any specific provided type definition.
     new  : fieldName: string * fieldType: Type -> ProvidedField
@@ -215,38 +226,45 @@ type ProvidedField =
 
     member SetFieldAttributes : attributes : FieldAttributes -> unit
 
-/// FSharp.Data addition: SymbolKind is used by AssemblyReplacer.fs
 /// Represents the type constructor in a provided symbol type.
 [<NoComparison>]
 type SymbolKind = 
+    /// Indicates that the type constructor is for a single-dimensional array
     | SDArray 
+    /// Indicates that the type constructor is for a multi-dimensional array
     | Array of int 
+    /// Indicates that the type constructor is for pointer types
     | Pointer 
+    /// Indicates that the type constructor is for byref types
     | ByRef 
-    | Generic of System.Type 
-    | FSharpTypeAbbreviation of (System.Reflection.Assembly * string * string[])
+    /// Indicates that the type constructor is for named generic types
+    | Generic of Type 
+    /// Indicates that the type constructor is for abbreviated types
+    | FSharpTypeAbbreviation of (Assembly * string * string[])
 
-/// FSharp.Data addition: ProvidedSymbolType is used by AssemblyReplacer.fs
 /// Represents an array or other symbolic type involving a provided type as the argument.
 /// See the type provider spec for the methods that must be implemented.
 /// Note that the type provider specification does not require us to implement pointer-equality for provided types.
 [<Class>]
 type ProvidedSymbolType =
-    inherit System.Type
+    inherit Type
 
     /// Returns the kind of this symbolic type
     member Kind : SymbolKind
+
     /// Return the provided types used as arguments of this symbolic type
-    member Args : list<System.Type>
+    member Args : list<Type>
 
 
-/// Provides symbolic provided types
+/// Helpers to build symbolic provided types
 [<Class>]
 type ProvidedTypeBuilder =
+
     /// Like typ.MakeGenericType, but will also work with unit-annotated types
-    static member MakeGenericType: genericTypeDefinition: System.Type * genericArguments: System.Type list -> System.Type
+    static member MakeGenericType: genericTypeDefinition: Type * genericArguments: Type list -> Type
+
     /// Like methodInfo.MakeGenericMethod, but will also work with unit-annotated types and provided types
-    static member MakeGenericMethod: genericMethodDefinition: System.Reflection.MethodInfo * genericArguments: System.Type list -> MethodInfo
+    static member MakeGenericMethod: genericMethodDefinition: MethodInfo * genericArguments: Type list -> MethodInfo
 
 /// Helps create erased provided unit-of-measure annotations.
 [<Class>]
@@ -255,40 +273,32 @@ type ProvidedMeasureBuilder =
     /// The ProvidedMeasureBuilder for building measures.
     static member Default : ProvidedMeasureBuilder
 
-    /// e.g. 1
-    member One : System.Type
-    /// e.g. m * kg
-    member Product : measure1: System.Type * measure1: System.Type  -> System.Type
-    /// e.g. 1 / kg
-    member Inverse : denominator: System.Type -> System.Type
+    /// Gets the measure indicating the "1" unit of measure, that is the unitless measure. 
+    member One : Type
 
-    /// e.g. kg / m
-    member Ratio : numerator: System.Type * denominator: System.Type -> System.Type
+    /// Returns the measure indicating the product of two units of measure, e.g. kg * m
+    member Product : measure1: Type * measure1: Type  -> Type
+
+    /// Returns the measure indicating the inverse of two units of measure, e.g. 1 / s
+    member Inverse : denominator: Type -> Type
+
+    /// Returns the measure indicating the ratio of two units of measure, e.g. kg / m
+    member Ratio : numerator: Type * denominator: Type -> Type
     
-    /// e.g. m * m 
-    member Square : ``measure``: System.Type -> System.Type
+    /// Returns the measure indicating the square of a unit of measure, e.g. m * m
+    member Square : ``measure``: Type -> Type
     
-    /// the SI unit from the F# core library, where the string is in capitals and US spelling, e.g. Meter
-    member SI : string -> System.Type
+    /// Returns the measure for an SI unit from the F# core library, where the string is in capitals and US spelling, e.g. Meter
+    member SI : unitName:string -> Type
     
+    /// Returns a type where the type has been annotated with the given types and/or units-of-measure.
     /// e.g. float<kg>, Vector<int, kg>
-    member AnnotateType : basic: System.Type * argument: System.Type list -> System.Type
+    member AnnotateType : basic: Type * argument: Type list -> Type
 
-
-/// Represents a provided static parameter.
-type ProvidedStaticParameter =
-    inherit System.Reflection.ParameterInfo
-    new : parameterName: string * parameterType:Type * ?parameterDefaultValue:obj -> ProvidedStaticParameter
-
-    /// Add XML documentation information to this provided constructor
-    member AddXmlDoc            : xmlDoc: string -> unit    
-
-    /// Add XML documentation information to this provided constructor, where the computation of the documentation is delayed until necessary
-    member AddXmlDocDelayed   : xmlDocFunction: (unit -> string) -> unit   
 
 /// Represents a provided type definition.
 type ProvidedTypeDefinition =
-    inherit System.Type
+    inherit Type
 
     /// Create a new provided type definition in a namespace. 
     new : assembly: Assembly * namespaceName: string * className: string * baseType: Type option -> ProvidedTypeDefinition
@@ -300,7 +310,7 @@ type ProvidedTypeDefinition =
     member AddInterfaceImplementation : interfaceType: Type -> unit    
 
     /// Add the given function as a set of on-demand computed interfaces.
-    member AddInterfaceImplementationsDelayed : interfacesFunction:(unit -> Type  list)-> unit    
+    member AddInterfaceImplementationsDelayed : interfacesFunction:(unit -> Type list)-> unit    
 
     /// Specifies that the given method body implements the given method declaration.
     member DefineMethodOverride : methodInfoBody: ProvidedMethod * methodInfoDeclaration: MethodInfo -> unit
@@ -314,8 +324,8 @@ type ProvidedTypeDefinition =
     /// Set the base type
     member SetBaseType             : Type -> unit    
 
-    /// Set the base type to a lazily evaluated value
-    member SetBaseTypeDelayed      : Lazy<Type option> -> unit    
+    /// Set the base type to a lazily evaluated value. Use this to delay realization of the base type as late as possible.
+    member SetBaseTypeDelayed      : baseTypeFunction:(unit -> Type) -> unit    
 
     /// Set underlying type for generated enums
     member SetEnumUnderlyingType : Type -> unit
@@ -329,13 +339,14 @@ type ProvidedTypeDefinition =
     member AddXmlDocComputed   : xmlDocFunction: (unit -> string) -> unit   
     
     /// Set the attributes on the provided type. This fully replaces the default TypeAttributes.
-    member SetAttributes        : System.Reflection.TypeAttributes -> unit
+    member SetAttributes        : TypeAttributes -> unit
     
     /// Reset the enclosing type (for generated nested types)
-    member ResetEnclosingType: enclosingType:System.Type -> unit
+    member ResetEnclosingType: enclosingType:Type -> unit
     
     /// Add a method, property, nested type or other member to a ProvidedTypeDefinition
     member AddMember         : memberInfo:MemberInfo      -> unit  
+
     /// Add a set of members to a ProvidedTypeDefinition
     member AddMembers        : memberInfos:list<#MemberInfo> -> unit
 
@@ -343,12 +354,12 @@ type ProvidedTypeDefinition =
     member AddMemberDelayed  : memberFunction:(unit -> #MemberInfo)      -> unit
 
     /// Add a set of members to a ProvidedTypeDefinition, delaying computation of the members until required by the compilation context.
-    member AddMembersDelayed : (unit -> list<#MemberInfo>) -> unit    
+    member AddMembersDelayed : membersFunction:(unit -> list<#MemberInfo>) -> unit    
     
     /// Add the types of the generated assembly as generative types, where types in namespaces get hierarchically positioned as nested types.
-    member AddAssemblyTypesAsNestedTypesDelayed : assemblyFunction:(unit -> System.Reflection.Assembly) -> unit
+    member AddAssemblyTypesAsNestedTypesDelayed : assemblyFunction:(unit -> Assembly) -> unit
 
-    // Parametric types
+    /// Define the static parameters available on a statically parameterized type
     member DefineStaticParameters     : parameters: ProvidedStaticParameter list * instantiationFunction: (string -> obj[] -> ProvidedTypeDefinition) -> unit
 
     /// Add definition location information to the provided type definition.
@@ -373,30 +384,35 @@ type ProvidedTypeDefinition =
     /// Add a custom attribute to the provided type definition.
     member AddCustomAttribute : CustomAttributeData -> unit
 
-    /// FSharp.Data addition: this method is used by Debug.fs and QuotationBuilder.fs
     /// Emulate the F# type provider type erasure mechanism to get the 
     /// actual (erased) type. We erase ProvidedTypes to their base type
     /// and we erase array of provided type to array of base type. In the
     /// case of generics all the generic type arguments are also recursively
     /// replaced with the erased-to types
-    static member EraseType : t:Type -> Type
+    static member EraseType : typ:Type -> Type
 
-    /// FSharp.Data addition: this is used to log the creation of root Provided Types to be able to debug caching/invalidation
+    /// Get or set a utility function to log the creation of root Provided Type. Used to debug caching/invalidation.
     static member Logger : (string -> unit) option ref
 
 /// A provided generated assembly
 type ProvidedAssembly =
+    /// Create a provided generated assembly
     new : assemblyFileName:string -> ProvidedAssembly
-    /// <summary>
+
     /// Emit the given provided type definitions as part of the assembly 
     /// and adjust the 'Assembly' property of all provided type definitions to return that
     /// assembly.
     ///
     /// The assembly is only emitted when the Assembly property on the root type is accessed for the first time.
     /// The host F# compiler does this when processing a generative type declaration for the type.
-    /// </summary>
-    /// <param name="enclosingTypeNames">An optional path of type names to wrap the generated types. The generated types are then generated as nested types.</param>
     member AddTypes : types : ProvidedTypeDefinition list -> unit
+
+    /// <summary>
+    /// Emit the given nested provided type definitions as part of the assembly.
+    /// and adjust the 'Assembly' property of all provided type definitions to return that
+    /// assembly.
+    /// </summary>
+    /// <param name="enclosingTypeNames">A path of type names to wrap the generated types. The generated types are then generated as nested types.</param>
     member AddNestedTypes : types : ProvidedTypeDefinition list * enclosingGeneratedTypeNames: string list -> unit
 
 #if FX_NO_LOCAL_FILESYSTEM
@@ -416,15 +432,20 @@ type TypeProviderForNamespaces =
     /// Initializes a type provider 
     new : unit -> TypeProviderForNamespaces
 
-    /// Add a namespace of provided types.
+    /// Invoked by the type provider to add a namespace of provided types in the specification of the type provider.
     member AddNamespace : namespaceName:string * types: ProvidedTypeDefinition list -> unit
 
-    /// FSharp.Data addition: this method is used by Debug.fs
-    /// Get all namespace with their provided types.
-    member Namespaces : (string * ProvidedTypeDefinition list) seq with get
+    /// Invoked by the type provider to get all provided namespaces with their provided types.
+    member Namespaces : seq<string * ProvidedTypeDefinition list> 
 
-    /// Invalidate the information provided by the provider
+    /// Invoked by the type provider to invalidate the information provided by the provider
     member Invalidate : unit -> unit
+
+    /// Invoked by the host of the type provider to get the static parameters for a method.
+    member GetStaticParametersForMethod : MethodBase -> ParameterInfo[]
+    
+    /// Invoked by the host of the type provider to apply the static argumetns for a method.
+    member ApplyStaticArgumentsForMethod : MethodBase * string * obj[] -> MethodBase
 
 #if FX_NO_LOCAL_FILESYSTEM
 #else
@@ -433,9 +454,10 @@ type TypeProviderForNamespaces =
     default ResolveAssembly : System.ResolveEventArgs -> Assembly
 
     /// Registers custom probing path that can be used for probing assemblies
-    member RegisterProbingFolder : folder : string -> unit
+    member RegisterProbingFolder : folder: string -> unit
+
     /// Registers location of RuntimeAssembly (from TypeProviderConfig) as probing folder
-    member RegisterRuntimeAssemblyLocationAsProbingFolder : cfg : Core.CompilerServices.TypeProviderConfig -> unit
+    member RegisterRuntimeAssemblyLocationAsProbingFolder : config: TypeProviderConfig -> unit
 
 #endif
 


### PR DESCRIPTION
This adds the helpers for the (optional) F# 4.0 support for static parameters on methods

I could separate out the cleanup but I think it's ok to include it here as part of a 4.0-era revision of ProvidedTypes.fs

Cheers
don

