### PR TITLE
Removed "Sealed" from generated types so that they may be subclassed.

### DIFF
--- a/src/ProvidedTypes.fs
+++ b/src/ProvidedTypes.fs
@@ -1276,7 +1276,6 @@ type ProvidedTypeDefinition(container:TypeContainer,className : string, baseType
     let mutable attributes   = 
         TypeAttributes.Public ||| 
         TypeAttributes.Class ||| 
-        TypeAttributes.Sealed |||
         enum (int32 TypeProviderTypeAttributes.IsErased)
 
 


### PR DESCRIPTION
I understand that this project is essentially a reference project, but (fsprojects/FsXaml)[https://github.com/fsprojects/FsXaml] is keeping its ProviderTypes.fs class in sync with this one. 

Allowing the provided types to be subclassed makes them much more useful and I can't see a technical reason to disallow it.