### PR TITLE
cleanup and convert types to target

### DIFF
--- a/src/ProvidedTypes.fsi
+++ b/src/ProvidedTypes.fsi
@@ -279,6 +279,13 @@ type ProvidedTypeBuilder =
     /// Like methodInfo.MakeGenericMethod, but will also work with unit-annotated types and provided types
     static member MakeGenericMethod: genericMethodDefinition: MethodInfo * genericArguments: Type list -> MethodInfo
 
+[<Class>]
+/// Used internally for ProvidedTypesContext
+type internal ZProvidedTypeBuilder =
+    new : convToTgt: (Type -> Type) -> ZProvidedTypeBuilder
+    member MakeGenericType: genericTypeDefinition: Type * genericArguments: Type list -> Type
+    member MakeGenericMethod: genericMethodDefinition: MethodInfo * genericArguments: Type list -> MethodInfo
+
 /// Helps create erased provided unit-of-measure annotations.
 [<Class>]
 type ProvidedMeasureBuilder =
@@ -320,6 +327,11 @@ type ProvidedTypeDefinition =
     /// Create a new provided type definition, to be located as a nested type in some type definition.
     // [<CompilerMessage("Please create a ProvidedTypesContext and use ctxt.ProvidedTypeDefinition to create a provided type definition. This will help allow your type provider to target portable profiles where that makes sense. Some argument names and values may need adjusting.", 8796)>]
     new : className : string * baseType: Type option -> ProvidedTypeDefinition
+
+
+    internal new : assembly: Assembly * namespaceName: string * className: string * baseType: Type option * convToTgt: (Type -> Type)  -> ProvidedTypeDefinition
+    internal new : className : string * baseType: Type option * convToTgt: (Type -> Type) -> ProvidedTypeDefinition
+
 
     /// Add the given type as an implemented interface.
     member AddInterfaceImplementation : interfaceType: Type -> unit    
@@ -371,8 +383,11 @@ type ProvidedTypeDefinition =
     /// Add a set of members to a ProvidedTypeDefinition, delaying computation of the members until required by the compilation context.
     member AddMembersDelayed : membersFunction:(unit -> list<#MemberInfo>) -> unit    
     
+#if NO_GENERATIVE
+#else
     /// Add the types of the generated assembly as generative types, where types in namespaces get hierarchically positioned as nested types.
     member AddAssemblyTypesAsNestedTypesDelayed : assemblyFunction:(unit -> Assembly) -> unit
+#endif
 
     /// Define the static parameters available on a statically parameterized type
     member DefineStaticParameters     : parameters: ProvidedStaticParameter list * instantiationFunction: (string -> obj[] -> ProvidedTypeDefinition) -> unit
@@ -409,6 +424,8 @@ type ProvidedTypeDefinition =
     /// Get or set a utility function to log the creation of root Provided Type. Used to debug caching/invalidation.
     static member Logger : (string -> unit) option ref
 
+#if NO_GENERATIVE
+#else
 /// A provided generated assembly
 type ProvidedAssembly =
     /// Create a provided generated assembly
@@ -434,6 +451,8 @@ type ProvidedAssembly =
 #else
     /// Register that a given file is a provided generated assembly
     static member RegisterGenerated : fileName:string -> Assembly
+#endif
+
 #endif
 
 

--- a/src/ProvidedTypesContext.fs
+++ b/src/ProvidedTypesContext.fs
@@ -400,10 +400,6 @@ type internal ProvidedTypesContext(referencedAssemblyPaths : string list) as thi
     member __.ReferencedAssemblies =  referencedAssemblies
     member x.TryGetFSharpCoreAssemblyVersion() = fsharpCoreRefVersion.Force()
 
-
-
-
-<<<<<<< HEAD
     /// Create a new provided static parameter, for use with DefineStaticParamaeters on a provided type definition.
     ///
     /// When making a cross-targeting type provider, use this method instead of the ProvidedParameter constructor from ProvidedTypes

--- a/tests/BasicGenerativeProvisionTests.fs
+++ b/tests/BasicGenerativeProvisionTests.fs
@@ -18,6 +18,9 @@ open FsUnit
 
 #nowarn "760" // IDisposable needs new
 
+#if NO_GENERATIVE
+#else
+
 [<TypeProvider>]
 type GenerativePropertyProviderWithStaticParams (config : TypeProviderConfig) as this =
     inherit TypeProviderForNamespaces ()
@@ -60,3 +63,4 @@ let ``GenerativePropertyProviderWithStaticParams generates for .NET 4.5 F# 4.0 c
     let assemContents = (typeProviderForNamespaces :> ITypeProvider).GetGeneratedAssemblyContents(t.Assembly)
     Assert.AreNotEqual(assemContents.Length, 0)
 
+#endif


### PR DESCRIPTION
The ProvidedTypes.fs implementation has long been a bit of a mess, because of the growing amount of code for generative type providers.

This extracts out the core of the code generator for quotations, and adds the option of having a ``#if NO_GENERATIVE`` define which removes the support for generative type providers.

This also correctly converts some remaining items to target types, especially ``typeof<Array>`` and friends reported as the base types for provided symbol types.

This cleanup is a preliminary to addressing #82 (cross-targeting generative type providers)

