### PR TITLE
Makes TP Testing work for F# Data

### DIFF
--- a/src/ProvidedTypesTesting.fs
+++ b/src/ProvidedTypesTesting.fs
@@ -563,7 +563,7 @@ type internal Testing() =
                 print " : "
                 print (toString true bt)
                 println()
-                t.GetMembers() 
+                t.GetMembers(BindingFlags.DeclaredOnly ||| BindingFlags.Instance ||| BindingFlags.Static ||| BindingFlags.Public) 
                 |> Seq.sortBy (fun m -> m.Name)
                 |> Seq.iter printMember
                 println()

--- a/src/ProvidedTypesTesting.fs
+++ b/src/ProvidedTypesTesting.fs
@@ -559,9 +559,9 @@ type internal Testing() =
                 | _ -> ""
                 |> print
                 print (toString true t)
-                if t.BaseType <> typeof<obj> then
-                    print " : "
-                    print (toString true t.BaseType)
+                let bt = if t.BaseType = null then typeof<obj> else t.BaseType
+                print " : "
+                print (toString true bt)
                 println()
                 t.GetMembers() 
                 |> Seq.sortBy (fun m -> m.Name)


### PR DESCRIPTION
 - `t.BaseType` can be `null`, which was breaking things
 - `t.GetMembers()` throws for some reason, but it works with the flags
 - I also changed the printing to print `: obj` for compatibility with F# Data

@dsyme I'll merge this directly, but if could have a look that would be great