### PR TITLE
Fix project file and remove printf

### DIFF
--- a/src/FSharp.TypeProviders.StarterPack.fsproj
+++ b/src/FSharp.TypeProviders.StarterPack.fsproj
@@ -60,8 +60,8 @@
     <Compile Include="ProvidedTypes.fs" />
     <Compile Include="AssemblyReader.fs" />
     <Compile Include="AssemblyReaderReflection.fs" />
+    <Compile Include="ProvidedTypesTesting.fs" />
     <Compile Include="ProvidedTypesContext.fs" />
-    <None Include="paket.references" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="mscorlib" />

--- a/src/ProvidedTypesTesting.fs
+++ b/src/ProvidedTypesTesting.fs
@@ -59,8 +59,6 @@ type internal Testing() =
     /// Simulates a real instance of TypeProviderConfig and then creates an instance of the last
     /// type provider added to a namespace by the type provider constructor
     static member GenerateProvidedTypeInstantiation (resolutionFolder: string, runtimeAssembly: string, runtimeAssemblyRefs: string list, typeProviderForNamespacesConstructor, args) =
-        printfn "TESTING: Generating one type, resolutionFolder = %s, runtimeAssembly = %s, runtimeAssemblyRefs = %A, args = %A" resolutionFolder runtimeAssembly runtimeAssemblyRefs args
-
         let cfg = Testing.MakeSimulatedTypeProviderConfig (resolutionFolder, runtimeAssembly, runtimeAssemblyRefs) 
 
         let typeProviderForNamespaces = typeProviderForNamespacesConstructor cfg :> TypeProviderForNamespaces


### PR DESCRIPTION
The additional `printf` makes F# Data build logs pretty much unusable when executed on a CI.