### PR TITLE
Consider genrated types inherited from System.Enum to be value types

### DIFF
--- a/src/ProvidedTypes.fs
+++ b/src/ProvidedTypes.fs
@@ -2350,7 +2350,7 @@ type ProvidedTypeDefinition(container:TypeContainer, className : string, baseTyp
 
     // Attributes, etc..
     override __.GetAttributeFlagsImpl() = adjustTypeAttributes attributes this.IsNested 
-    override this.IsValueTypeImpl() = if this.BaseType <> null then this.BaseType.IsValueType else false
+    override this.IsValueTypeImpl() = if this.BaseType <> null then this.BaseType = typeof<Enum> || this.BaseType.IsValueType else false
     override __.IsArrayImpl() = false
     override __.IsByRefImpl() = false
     override __.IsPointerImpl() = false


### PR DESCRIPTION
I was looking into how provided types are translated to IL to find out the root cause  of #100 and found that `ProvidedTypeDefinition.IsValueType` returns incorrect values when generated type is an enumeration (base type is `System.Enum`, which is itself is not a value type). 
The PR contains a fix for that (and also resolves #100). 

I don't really have full understanding of why it resolves #100, so I'd still appreciate some explanation.