### PR TITLE
Comment out debugging prints

### DIFF
--- a/src/ProvidedTypes.fs
+++ b/src/ProvidedTypes.fs
@@ -2886,13 +2886,13 @@ type TypeProviderForNamespaces(namespacesAndTypes : list<(string * list<Provided
     member this.Invalidate() = invalidateE.Trigger(this,EventArgs())
 
     member __.GetStaticParametersForMethod(mb: MethodBase) =
-        printfn "In GetStaticParametersForMethod"
+        // printfn "In GetStaticParametersForMethod"
         match mb with
         | :? ProvidedMethod as t -> t.GetStaticParameters()
         | _ -> [| |]
 
     member __.ApplyStaticArgumentsForMethod(mb: MethodBase, mangledName, objs) = 
-        printfn "In ApplyStaticArgumentsForMethod"
+        // printfn "In ApplyStaticArgumentsForMethod"
         match mb with
         | :? ProvidedMethod as t -> t.ApplyStaticArguments(mangledName, objs) :> MethodBase
         | _ -> failwith (sprintf "ApplyStaticArguments: static parameters for method %s are unexpected" mb.Name)


### PR DESCRIPTION
All the other prints are commented out so I guess those two are remaining from when the new static parameter where being tested. They are a bit distracting when using Fable as the stdout is used to communicate with another process.