### PR TITLE
Add ReflectedDefinitionAttribute to provided methods

### DIFF
--- a/src/ProvidedTypes.fsi
+++ b/src/ProvidedTypes.fsi
@@ -23,6 +23,7 @@ type ProvidedParameter =
     // [<CompilerMessage("Please create a ProvidedTypesContext and use ctxt.ProvidedParameter to create a provided parameter. This will help allow your type provider to target portable profiles where that makes sense. Some argument names and values may need adjusting.", 8796)>]
     new : parameterName: string * parameterType: Type * ?isOut:bool * ?optionalValue:obj -> ProvidedParameter
     member IsParamArray : bool with get,set
+    member IsReflectedDefinition : bool with get,set
 
 /// Represents a provided static parameter.
 type ProvidedStaticParameter =


### PR DESCRIPTION
Even if the arguments of a provided method are received as expressions, if you want an actual quotation when accessing the argument, you still need to add the `ReflectedDefinition` attribute to the provided parameter. This PR adds this possibility. A usage example can be seen [here](https://github.com/bazingatechnologies/FSharp.Data.GraphQL/pull/68/commits/c981ba01bc84f50586a582d2e1b304875d97d1a8).