### PR TITLE
Fix code sample in README.MD to match the code in the sample source code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ let ctxt = ProvidedTypesContext.Create(config)
 to your code and always create provided entities using this ``ctxt`` object:
 
 ```fsharp
-let myType = ctxt.ProvidedTypeDefinition(asm, ns, "MyType", typeof<obj>)
+let myType = ctxt.ProvidedTypeDefinition(asm, ns, "MyType", Some typeof<obj>)
 ```
 
 This is shown in the example below.
@@ -78,7 +78,7 @@ type BasicProvider (config : TypeProviderConfig) as this =
     let ctxt = ProvidedTypesContext.Create(config)
 
     let createTypes () =
-        let myType = ctxt.ProvidedTypeDefinition(asm, ns, "MyType", typeof<obj>)
+        let myType = ctxt.ProvidedTypeDefinition(asm, ns, "MyType", Some typeof<obj>)
         let myProp = ctxt.ProvidedProperty("MyProperty", typeof<string>, IsStatic = true, getterCode = (fun args -> <@@ "Hello world" @@>))
         myType.AddMember(myProp)
         [myType]


### PR DESCRIPTION
The current code sample in README.MD is wrong.

The ProvidedTypeDefinition constructor has option typed parameter, therefore the calling of the parameter must add Some and this is in sync with the source code in the TP samples.

For example:
```fsharp
let myType = ctxt.ProvidedTypeDefinition(asm, ns, "MyType", typeof<obj>)
```

Should be:

```fsharp
let myType = ctxt.ProvidedTypeDefinition(asm, ns, "MyType", Some typeof<obj>)
```

