### PR TITLE
Fix #46: AddXmlDocComputed is not adding xml doc

### DIFF
--- a/src/ProvidedTypes.fs
+++ b/src/ProvidedTypes.fs
@@ -1224,7 +1224,8 @@ module internal Misc =
         member __.AddCustomAttribute(attribute) = customAttributes.Add(attribute)
         member __.GetCustomAttributesData() = 
             [| yield! customAttributesOnce.Force()
-               match xmlDocAlwaysRecomputed with None -> () | Some f -> customAttributes.Add(mkXmlDocCustomAttributeData (f()))  |]
+               // Recomputed XML doc is evaluated on every call to GetCustomAttributesData()
+               match xmlDocAlwaysRecomputed with None -> () | Some f -> yield mkXmlDocCustomAttributeData (f())  |]
             :> IList<_>
 
 


### PR DESCRIPTION
The recomputed XML Doc attribute is no longer added to the internal custom attributes collection (after customAttributesOnce has been evaluated), but instead returned as part of the custom attribute array when calling GetCustomAttributesData()