### PR TITLE
Fix for Mono 5.0

### DIFF
--- a/src/ProvidedTypes.fs
+++ b/src/ProvidedTypes.fs
@@ -620,9 +620,9 @@ type CodeGenerator(assemblyMainModule: ModuleBuilder, uniqueLambdaTypeName,
                    isLiteralEnumField: FieldInfo -> bool,
                    ilg: ILGenerator, locals:Dictionary<Quotations.Var,LocalBuilder>, parameterVars) = 
 
-    // This is gross. TypeBuilderInstantiation should really be a public type, since we
-    // have to use alternative means for various Method/Field/Constructor lookups.  However since 
-    // it isn't we resort to this technique...
+    // TypeBuilderInstantiation should really be a public type, since we
+    // have to use alternative means for various Method/Field/Constructor lookups on this kind of type.
+    // Also, on Mono 3.x and 4.x this type had a different name.
     let TypeBuilderInstantiationType = 
         let runningOnMono = try System.Type.GetType("Mono.Runtime") <> null with e-> false
         let ty = 

--- a/src/ProvidedTypes.fs
+++ b/src/ProvidedTypes.fs
@@ -634,7 +634,6 @@ type CodeGenerator(assemblyMainModule: ModuleBuilder, uniqueLambdaTypeName,
             else
                 Type.GetType("System.Reflection.Emit.TypeBuilderInstantiation")
 
-        assert (not (isNull ty))
         ty
     
     // TODO: this works over FSharp.Core 4.4.0.0 types and methods. These types need to be retargeted to the target runtime.

--- a/src/ProvidedTypes.fs
+++ b/src/ProvidedTypes.fs
@@ -623,7 +623,7 @@ type CodeGenerator(assemblyMainModule: ModuleBuilder, uniqueLambdaTypeName,
     // This is gross. TypeBuilderInstantiation should really be a public type, since we
     // have to use alternative means for various Method/Field/Constructor lookups.  However since 
     // it isn't we resort to this technique...
-    let TypeBuilderInstantiationT = 
+    let TypeBuilderInstantiationType = 
         let runningOnMono = try System.Type.GetType("Mono.Runtime") <> null with e-> false
         let ty = 
             if runningOnMono then

--- a/src/ProvidedTypes.fs
+++ b/src/ProvidedTypes.fs
@@ -620,11 +620,23 @@ type CodeGenerator(assemblyMainModule: ModuleBuilder, uniqueLambdaTypeName,
                    isLiteralEnumField: FieldInfo -> bool,
                    ilg: ILGenerator, locals:Dictionary<Quotations.Var,LocalBuilder>, parameterVars) = 
 
-    let TypeBuilderInstantiationType = 
-        let runningOnMono = try System.Type.GetType("Mono.Runtime") <> null with e -> false 
-        let typeName = if runningOnMono then "System.Reflection.MonoGenericClass" else "System.Reflection.Emit.TypeBuilderInstantiation"
-        typeof<TypeBuilder>.Assembly.GetType(typeName)
+    // This is gross. TypeBuilderInstantiation should really be a public type, since we
+    // have to use alternative means for various Method/Field/Constructor lookups.  However since 
+    // it isn't we resort to this technique...
+    let TypeBuilderInstantiationT = 
+        let runningOnMono = try System.Type.GetType("Mono.Runtime") <> null with e-> false
+        let ty = 
+            if runningOnMono then
+                let ty = Type.GetType("System.Reflection.MonoGenericClass")
+                match ty with
+                | null -> Type.GetType("System.Reflection.Emit.TypeBuilderInstantiation")
+                | _ -> ty
+            else
+                Type.GetType("System.Reflection.Emit.TypeBuilderInstantiation")
 
+        assert (not (isNull ty))
+        ty
+    
     // TODO: this works over FSharp.Core 4.4.0.0 types and methods. These types need to be retargeted to the target runtime.
 
     let GetTypeFromHandleMethod() = typeof<Type>.GetMethod("GetTypeFromHandle")


### PR DESCRIPTION
See https://github.com/fsharp/fsharp/issues/738 and https://github.com/fsprojects/FSharp.TypeProviders.StarterPack/issues/121

All type providers that need to work with Mono 5.0 should be updated to use this copy