### PR TITLE
Parameter names synced (from `fsi` to `fs` file)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+#### 2.1.0 - August 25 2017
+* Mono 5 support
+* Parameter names unification
 
 #### 2.0.0 - 02/02/2016
 * Updates for cross-targeting of type providers

--- a/build.fsx
+++ b/build.fsx
@@ -74,7 +74,7 @@ let sources =
 // Clean build results
 
 Target "Clean" (fun _ ->
-    CleanDirs [outputPath; workingDir;testDir]
+    CleanDirs [outputPath; workingDir]
 )
 
 // --------------------------------------------------------------------------------------

--- a/src/ProvidedTypes.fsi
+++ b/src/ProvidedTypes.fsi
@@ -297,7 +297,7 @@ type ProvidedMeasureBuilder =
     member One : Type
 
     /// Returns the measure indicating the product of two units of measure, e.g. kg * m
-    member Product : measure1: Type * measure1: Type  -> Type
+    member Product : measure1: Type * measure2: Type  -> Type
 
     /// Returns the measure indicating the inverse of two units of measure, e.g. 1 / s
     member Inverse : denominator: Type -> Type


### PR DESCRIPTION
This PR actually fix issue #127
I did sync parameter names from `fsi` to `fs` file in order to save backward compatibility

but would be nice to have an additional pair of eyes before merge and release