### PR TITLE
Fix for ProvidedTypesContext.fs when compiling with dotnet.exe

### DIFF
--- a/src/ProvidedTypesContext.fs
+++ b/src/ProvidedTypesContext.fs
@@ -91,7 +91,7 @@ type internal AssemblyReplacer(designTimeAssemblies: Lazy<Assembly[]>, reference
         // then we only map it to assemblies with a name specified in `assemblyReplacementMap`
         let notRestrictedOrMatching =
             assemblyReplacementMap
-            |> Seq.forall (fun (originalName, newName) ->
+            |> Seq.forall (fun (originalName:string, newName:string) ->
                 if originalAssemblyName.StartsWith originalName then asm.FullName.StartsWith(newName)
                 else true)
 


### PR DESCRIPTION
With old VS everything works fine, but when compiling with dotnet.exe, for whatever reason, FSharp couldn't resolve type: `String.StartsWith(value: char)` vs `String.StartsWith(value: string)`


```
C:\git\FSharp.TypeProviders.StarterPack\src\ProvidedTypesContext.fs(95,20): error FS0041: A unique overload for method 'StartsWith' could not be determined based on type information prior to this program point. A type annotation may be needed. Candidates: String.StartsWith(value: char) : bool, String.StartsWith(value: string) : bool [C:\git\myProj.fsproj]
C:\git\FSharp.TypeProviders.StarterPack\src\ProvidedTypesContext.fs(95,70): error FS0041: A unique overload for method 'StartsWith' could not be determined based on type information prior to this program point. A type annotation may be needed. Candidates: String.StartsWith(value: char) : bool, String.StartsWith(value: string) : bool [C:\git\myProj.fsproj]
```

This PR will fix the problem just by giving a type hint to the compiler.